### PR TITLE
ensure setting defaults are always applied

### DIFF
--- a/src/observable-store.ts
+++ b/src/observable-store.ts
@@ -37,8 +37,8 @@ export class ObservableStore<T> {
     private _clonerService: ClonerService;
     private _settings: ObservableStoreSettings
 
-    constructor(settings: ObservableStoreSettings = settingsDefaults) {
-        this._settings = settings;
+    constructor(settings: ObservableStoreSettings) {
+        this._settings = Object.assign({}, settingsDefaults, settings);
         this._clonerService = clonerService;
         
         this.stateChanged = this._stateDispatcher.asObservable();


### PR DESCRIPTION
If we provide a value for one of the defaults in the constructor parameter, then as a parameter is being provided the defaults for the other properties in the settings default will not get applied unless we provide values for all the defaults in our constructor parameter.

This change allows the user to supply a single default in the constructor parameter and yet continue to use defaults for the other parameters without having to supply them.

In reality, as the other defaults are all false or null, having them as undefined should mean no impact on behaviour. However it felt better to take the values from the settings if not explicitly provided.