### PR TITLE
fix: switch to testability for angular 9

### DIFF
--- a/modules/observable-store-extensions/angular/angular-devtools-extension.ts
+++ b/modules/observable-store-extensions/angular/angular-devtools-extension.ts
@@ -1,13 +1,16 @@
 export class AngularDevToolsExtension {
-    private window = (window as any);
-    private rootElements: any;
+    private window = window as any;
+    private testability: any;
     private router: any;
     private ngZone: any;
 
     constructor() {
-        this.rootElements = this.window.ng.probe(this.window.getAllAngularRootElements()[0]);
-        const providers = this.rootElements.injector.view.root.ngModule._providers;        
-        this.router = providers.find(p => p && p.constructor && p.constructor.name === 'Router');
+        this.testability = this.window.getAllAngularTestabilities()[0];
+
+        this.router = this.testability.findProviders(
+            this.window.getAllAngularRootElements()[0],
+            'Router'
+        );
 
         this.ngZone = this.getNgZone();
     }
@@ -30,11 +33,9 @@ export class AngularDevToolsExtension {
 
     private getNgZone() {
         try {
-            return this.rootElements.injector.get(this.window.ng.coreTokens.NgZone);
-        }
-        catch (e) {
+            return this.testability._ngZone;
+        } catch (e) {
             console.log(e);
         }
     }
-
 }


### PR DESCRIPTION
After some investigation this is what I have found out:

The `ng.getInjector(elementOrDir)` is scoped to the providers injected directly into the component or directive passed to the method rather than what is injected into global scope.

There does seem to be a method in the newly favoured Testability class that will fetch a provider, however, as of writing, it is still to be implemented:
https://github.com/angular/angular/blob/cd9ae66b357bd4b5f97aa60cea38e48acb015325/packages/core/src/testability/testability.ts#L221

On the upside, it does give much easier access to the `_ngZone` object, as outlined in the changes.

cc @DanWahlin 