### PR TITLE
Fix an issue with cloning map objects

### DIFF
--- a/modules/observable-store/utilities/cloner.service.ts
+++ b/modules/observable-store/utilities/cloner.service.ts
@@ -22,6 +22,10 @@ export class ClonerService {
                     result = this.newRegExp(value);
                     return result;
                 }
+                else if (value instanceof Map) {
+                    result = new Map(value);
+                    return result;
+                }
 
                 result = JSON.parse(JSON.stringify(value));
                 this.fixTypes(value, result);


### PR DESCRIPTION
Noticed an issue when attempting to retrieve a map from the observable store.  The cloner service needed to properly deep clone a map object.