### PR TITLE
added deep clone returned state global setting

### DIFF
--- a/modules/observable-store/interfaces.ts
+++ b/modules/observable-store/interfaces.ts
@@ -26,6 +26,12 @@ export interface BaseStoreSettings {
      * DEPRECATED. Since this is deprecated, use `stateWithPropertyChanges` or `globalStateWithPropertyChanges` instead.
      */
     includeStateChangesOnSubscribe?: boolean;
+
+    /**
+     * Can be used to determine if the returned state will be deep cloned or not in global area. Uses as default parameter
+     * for all methods which has `deepCloneReturnedState` parameter
+     */
+    deepCloneReturnedState?: boolean;
 }
 
 export interface ObservableStoreSettings extends BaseStoreSettings, StateSliceSelector { }

--- a/modules/observable-store/observable-store-base.ts
+++ b/modules/observable-store/observable-store-base.ts
@@ -2,27 +2,24 @@ import { BehaviorSubject } from 'rxjs';
 import { ClonerService } from './utilities/cloner.service';
 import { ObservableStoreSettings, ObservableStoreGlobalSettings, StateWithPropertyChanges, ObservableStoreExtension } from './interfaces';
 
-/**
- * Default settings & global settings
- */
-export const DEFAULT_SETTINGS: ObservableStoreGlobalSettings = {
-    deepCloneReturnedState: true,
-    trackStateHistory: false,
-    // deprecated
-    includeStateChangesOnSubscribe: false,
-    logStateChanges: false,
-    isProduction: false
-} as const;
-
 // Will be used to create a singleton
 class ObservableStoreBase {
     private _storeState: Readonly<any> = null;
     private _clonerService = new ClonerService();
     private _extensions = [];
 
-    readonly defaultGlobalSettings = DEFAULT_SETTINGS;
+    /**
+     * Default settings & global settings
+     */
+    readonly defaultGlobalSettings: ObservableStoreGlobalSettings = {
+        deepCloneReturnedState: true,
+        trackStateHistory: false,
+        // deprecated
+        includeStateChangesOnSubscribe: false,
+        logStateChanges: false,
+        isProduction: false
+    } as const;
 
-    readonly settingsDefaults = DEFAULT_SETTINGS;
     stateHistory: any[] = [];
     globalStateDispatcher = new BehaviorSubject<any>(null);
     globalStateWithChangesDispatcher = new BehaviorSubject<StateWithPropertyChanges<any>>(null);

--- a/modules/observable-store/observable-store-base.ts
+++ b/modules/observable-store/observable-store-base.ts
@@ -2,23 +2,31 @@ import { BehaviorSubject } from 'rxjs';
 import { ClonerService } from './utilities/cloner.service';
 import { ObservableStoreSettings, ObservableStoreGlobalSettings, StateWithPropertyChanges, ObservableStoreExtension } from './interfaces';
 
+/**
+ * Default settings & global settings
+ */
+export const DEFAULT_SETTINGS: ObservableStoreGlobalSettings = {
+    deepCloneReturnedState: true,
+    trackStateHistory: false,
+    // deprecated
+    includeStateChangesOnSubscribe: false,
+    logStateChanges: false,
+    isProduction: false
+} as const;
+
 // Will be used to create a singleton
-class ObservableStoreBase {  
+class ObservableStoreBase {
     private _storeState: Readonly<any> = null;
     private _clonerService = new ClonerService();
     private _extensions = [];
-    
-    settingsDefaults: ObservableStoreSettings = {
-        trackStateHistory: false,
-        logStateChanges: false,
-        // deprecated
-        includeStateChangesOnSubscribe: false,
-        stateSliceSelector: null
-    };    
+
+    readonly defaultGlobalSettings = DEFAULT_SETTINGS;
+
+    readonly settingsDefaults = DEFAULT_SETTINGS;
     stateHistory: any[] = [];
     globalStateDispatcher = new BehaviorSubject<any>(null);
     globalStateWithChangesDispatcher = new BehaviorSubject<StateWithPropertyChanges<any>>(null);
-    globalSettings: ObservableStoreGlobalSettings = null;
+    globalSettings: ObservableStoreGlobalSettings = { ...this.defaultGlobalSettings };
     services: any[] = []; // Track all services reading/writing to store. Useful for extensions like DevToolsExtension.
 
     initializeState(state: any) {

--- a/modules/observable-store/observable-store.ts
+++ b/modules/observable-store/observable-store.ts
@@ -57,7 +57,7 @@ export class ObservableStore<T> {
     }
 
     constructor(settings: ObservableStoreSettings) {
-        this._settings = { ...ObservableStoreBase.settingsDefaults, ...ObservableStoreBase.globalSettings, ...settings };
+        this._settings = { ...ObservableStoreBase.globalSettings, ...settings };
         this.stateChanged = this._stateDispatcher$.asObservable();
         this.globalStateChanged = ObservableStoreBase.globalStateDispatcher.asObservable();
 

--- a/modules/observable-store/tests/mocks.ts
+++ b/modules/observable-store/tests/mocks.ts
@@ -57,22 +57,22 @@ export class UserStore extends ObservableStore<MockState> {
         this.resetStateHistory();
     }
 
-    updateUser(user: MockUser, deepCloneState: boolean = true) {
+    updateUser(user: MockUser, deepCloneState?: boolean) {
         this.setState({ user }, 'Update User', true, deepCloneState);
     }
 
-    updateMap(map: Map<any, any>, deepCloneState: boolean = true) {
+    updateMap(map: Map<any, any>, deepCloneState?: boolean) {
         this.setState({ map }, 'Update Map', true, deepCloneState);
     }
 
-    addToUsers(user: MockUser, deepCloneState: boolean = true) {
+    addToUsers(user: MockUser, deepCloneState?: boolean) {
         const state = this.getState(deepCloneState);
         let users = (state && state.users) ? state.users : [];
         users.push(user);
         this.setState({ users }, 'Update Users', true, deepCloneState);
     }
 
-    getCurrentState(deepCloneReturnedState: boolean = true) {
+    getCurrentState(deepCloneReturnedState?: boolean) {
         return this.getState(deepCloneReturnedState);
     }
 

--- a/modules/observable-store/tests/observable-store.spec.ts
+++ b/modules/observable-store/tests/observable-store.spec.ts
@@ -16,6 +16,11 @@ beforeEach(() => {
 
 describe('Observable Store', () => {
 
+  beforeEach(() => {
+    // reset globalSettings before each run to be sure it is clean
+    ObservableStore.globalSettings = {};
+  });
+
   describe('Changing state', () => {
 
     it('should change a single property', () => {
@@ -245,6 +250,13 @@ describe('Observable Store', () => {
       expect(userStore.currentState.user.address.city).toEqual('Las Vegas');
     });
 
+    it('should NOT deep clone by default when deepCloneReturnedState is false', () => {
+      ObservableStore.globalSettings = { deepCloneReturnedState: false };
+      userStore.updateUser(user); // don't set second parameter; it should be get from global settings
+      user.address.city = 'Las Vegas';
+      expect(userStore.currentState.user.address.city).toEqual('Las Vegas');
+    });
+
     it('should NOT deep clone when setState or getState called', () => {
       // Set state but don't clone
       userStore.updateUser(user, false);
@@ -297,11 +309,10 @@ describe('Observable Store', () => {
   });
 
   describe('globalSettings', () => {
-
-    it('should store global settings', () => {
+    it('should store and merge with default global settings', () => {
       ObservableStore.globalSettings = { trackStateHistory: true };
       const settingsKeys = Object.getOwnPropertyNames(ObservableStore.globalSettings);
-      expect(settingsKeys.length).toEqual(1);
+      expect(settingsKeys.length).toBeGreaterThan(1);
     });
 
     it('should error when no global settings passed', () => {


### PR DESCRIPTION
Hi Dan!
First of all - thank you for the coolest lib.
I seen https://github.com/DanWahlin/Observable-Store/issues/92 some time ago and i need that feature as well.
Could you please consider my PR?
Not sure i properly understand your vision of setting hierarhy.
I think as follow: 
  - global settings has some defaults;
  - user could redefine part of global settings;
  - user could pass specific settings (subset of global settings) for each store instance via construstor; in that case instance settings has a higher priority rather than global settings.

In original code global settings has the last word and nailed to the table - cannot be changed via constructor of store instance.