### PR TITLE
Get state property using state slice selector

### DIFF
--- a/modules/observable-store/observable-store.ts
+++ b/modules/observable-store/observable-store.ts
@@ -171,8 +171,7 @@ export class ObservableStore<T> {
      * since only the defined property value will be returned (and cloned) rather than the entire 
      * store value. If using TypeScript (optional) then the generic property type used with the 
      * function call will be the return type.
-     * If a `stateSliceSelector` has been set, the specific slice will be searched first. Falling back
-     * to the top level state if property is not found.
+     * If a `stateSliceSelector` has been set, the specific slice will be searched first.
      */
     protected getStateSliceProperty<TProp>(propertyName: string, deepCloneReturnedState: boolean = true): TProp {
         if (this._settings.stateSliceSelector) {
@@ -181,7 +180,7 @@ export class ObservableStore<T> {
                 return state[propertyName];
             }
         }
-        return this.getStateProperty<TProp>(propertyName, deepCloneReturnedState);
+        return null;
     }
 
     /**

--- a/modules/observable-store/observable-store.ts
+++ b/modules/observable-store/observable-store.ts
@@ -47,7 +47,7 @@ export class ObservableStore<T> {
      * (which has the individual properties/data that were changed in the store).
      */
     globalStateWithPropertyChanges: Observable<StateWithPropertyChanges<T>>;
-    
+
 
     /**
      * Retrieve state history. Assumes trackStateHistory setting was set on the store.
@@ -57,7 +57,7 @@ export class ObservableStore<T> {
     }
 
     constructor(settings: ObservableStoreSettings) {
-        this._settings = { ...ObservableStoreBase.settingsDefaults, ...settings, ...ObservableStoreBase.globalSettings };        
+        this._settings = { ...ObservableStoreBase.settingsDefaults, ...settings, ...ObservableStoreBase.globalSettings };
         this.stateChanged = this._stateDispatcher$.asObservable();
         this.globalStateChanged = ObservableStoreBase.globalStateDispatcher.asObservable();
 
@@ -151,7 +151,7 @@ export class ObservableStore<T> {
      * be returned and it's up to the user to ensure the state isn't change from outside the store. Setting it to false can be
      * useful in cases where read-only cached data is stored and must be retrieved as quickly as possible without any cloning.
      */
-    protected getState(deepCloneReturnedState: boolean = true) : T {
+    protected getState(deepCloneReturnedState: boolean = true): T {
         return this._getStateOrSlice(deepCloneReturnedState);
     }
 
@@ -161,8 +161,27 @@ export class ObservableStore<T> {
      * store value. If using TypeScript (optional) then the generic property type used with the 
      * function call will be the return type.
      */
-    protected getStateProperty<TProp>(propertyName: string, deepCloneReturnedState: boolean = true) : TProp {
+    protected getStateProperty<TProp>(propertyName: string, deepCloneReturnedState: boolean = true): TProp {
         return ObservableStoreBase.getStoreState(propertyName, deepCloneReturnedState);
+    }
+
+
+    /**
+     * Retrieve a specific property from the store's state which can be more efficient than getState() 
+     * since only the defined property value will be returned (and cloned) rather than the entire 
+     * store value. If using TypeScript (optional) then the generic property type used with the 
+     * function call will be the return type.
+     * If a `stateSliceSelector` has been set, the specific slice will be searched first. Falling back
+     * to the top level state if property is not found.
+     */
+    protected getStateSliceProperty<TProp>(propertyName: string, deepCloneReturnedState: boolean = true): TProp {
+        if (this._settings.stateSliceSelector) {
+            const state = this._getStateOrSlice(deepCloneReturnedState);
+            if (state.hasOwnProperty(propertyName)) {
+                return state[propertyName];
+            }
+        }
+        return this.getStateProperty<TProp>(propertyName, deepCloneReturnedState);
     }
 
     /**
@@ -174,10 +193,10 @@ export class ObservableStore<T> {
      * to determine if the state will be deep cloned before it is added to the store. Setting it to false can be
      * useful in cases where read-only cached data is stored and must added to the store as quickly as possible without any cloning.
      */
-    protected setState(state: Partial<T> | stateFunc<T>, 
-        action?: string, 
+    protected setState(state: Partial<T> | stateFunc<T>,
+        action?: string,
         dispatchState: boolean = true,
-        deepCloneState: boolean = true) : T { 
+        deepCloneState: boolean = true): T {
 
         // Needed for tracking below (don't move or delete)
         const previousState = this.getState(deepCloneState);
@@ -195,13 +214,13 @@ export class ObservableStore<T> {
         }
 
         if (this._settings.trackStateHistory) {
-            ObservableStoreBase.stateHistory.push({ 
-                action, 
-                beginState: previousState, 
-                endState: this.getState(deepCloneState) 
+            ObservableStoreBase.stateHistory.push({
+                action,
+                beginState: previousState,
+                endState: this.getState(deepCloneState)
             });
         }
-        
+
         if (dispatchState) {
             this.dispatchState(state as any);
         }
@@ -220,10 +239,10 @@ export class ObservableStore<T> {
      */
     protected logStateAction(state: any, action: string) {
         if (this._settings.trackStateHistory) {
-            ObservableStoreBase.stateHistory.push({ 
-                action, 
-                beginState: this.getState(), 
-                endState: ObservableStoreBase.deepClone(state) 
+            ObservableStoreBase.stateHistory.push({
+                action,
+                beginState: this.getState(),
+                endState: ObservableStoreBase.deepClone(state)
             });
         }
     }
@@ -251,7 +270,7 @@ export class ObservableStore<T> {
      * Dispatch the store's state without modifying the store state. Service state can be dispatched as well as the global store state. 
      * If `dispatchGlobalState` is false then global state will not be dispatched to subscribers (defaults to `true`). 
      */
-    protected dispatchState(stateChanges: Partial<T>, dispatchGlobalState: boolean = true) {       
+    protected dispatchState(stateChanges: Partial<T>, dispatchGlobalState: boolean = true) {
         // Get store state or slice of state
         const clonedStateOrSlice = this._getStateOrSlice(true);
 
@@ -261,7 +280,7 @@ export class ObservableStore<T> {
         // includeStateChangesOnSubscribe is deprecated
         if (this._settings.includeStateChangesOnSubscribe) {
             console.warn('includeStateChangesOnSubscribe is deprecated. ' +
-                        'Subscribe to stateChangedWithChanges or globalStateChangedWithChanges instead.');
+                'Subscribe to stateChangedWithChanges or globalStateChangedWithChanges instead.');
             this._stateDispatcher$.next({ state: clonedStateOrSlice, stateChanges } as any);
             ObservableStoreBase.globalStateDispatcher.next({ state: clonedGlobalState, stateChanges });
         }

--- a/modules/observable-store/observable-store.ts
+++ b/modules/observable-store/observable-store.ts
@@ -279,7 +279,7 @@ export class ObservableStore<T> {
         // includeStateChangesOnSubscribe is deprecated
         if (this._settings.includeStateChangesOnSubscribe) {
             console.warn('includeStateChangesOnSubscribe is deprecated. ' +
-                'Subscribe to stateChangedWithChanges or globalStateChangedWithChanges instead.');
+                         'Subscribe to stateChangedWithChanges or globalStateChangedWithChanges instead.');
             this._stateDispatcher$.next({ state: clonedStateOrSlice, stateChanges } as any);
             ObservableStoreBase.globalStateDispatcher.next({ state: clonedGlobalState, stateChanges });
         }

--- a/modules/observable-store/tests/observable-store.spec.ts
+++ b/modules/observable-store/tests/observable-store.spec.ts
@@ -346,7 +346,7 @@ describe('Observable Store', () => {
       }
       catch (e) {
         expect(e.message).toEqual('The store state has already been initialized. initializeStoreState() can ' +
-          'only be called once BEFORE any store state has been set.');
+                                  'only be called once BEFORE any store state has been set.');
       }
 
     });

--- a/modules/observable-store/tests/observable-store.spec.ts
+++ b/modules/observable-store/tests/observable-store.spec.ts
@@ -58,8 +58,8 @@ describe('Observable Store', () => {
 
     it('should execute an anonymous function on a slice of data', () => {
       const updateUser: stateFunc<MockState> = (state: MockState) => {
-        if (!state) { 
-          state = { prop1: null, prop2: null, user: null, users: null } ;
+        if (!state) {
+          state = { prop1: null, prop2: null, user: null, users: null };
         }
         state.user = { name: 'fred' };
         return { user: state.user };
@@ -189,7 +189,25 @@ describe('Observable Store', () => {
       expect(state.name).toBeTruthy();
       expect(state.users).toBeUndefined();
     });
-    
+
+  });
+
+  describe('getStateSliceProperty', () => {
+
+    it('should retrieve single user property from slice when string property name passed', () => {
+      userStore = new UserStore({
+        stateSliceSelector: state => {
+          if (state) {
+            return { ...state.user };
+          }
+        }
+      });
+      userStore.setState({ user: getUser() });
+      expect(userStore.currentState).toBeTruthy();
+      let userName = userStore.getStateSliceProperty('name');
+      expect(userName).toBeTruthy();
+    });
+
   });
 
   describe('SliceSelector', () => {
@@ -222,7 +240,7 @@ describe('Observable Store', () => {
       user = getUser();
     });
 
-    it('should clone Map object added to store', ()=> {
+    it('should clone Map object added to store', () => {
       let map = new Map();
       map.set('key1', 22);
       map.set('key2', 32);
@@ -230,7 +248,7 @@ describe('Observable Store', () => {
       let state = userStore.getCurrentState();
       expect(map).toBe(map);
       expect(state.map).not.toBe(map);
-      expect (state.map.size).toEqual(map.size);
+      expect(state.map.size).toEqual(map.size);
     });
 
     it('should deep clone when setState called', () => {
@@ -328,7 +346,7 @@ describe('Observable Store', () => {
       }
       catch (e) {
         expect(e.message).toEqual('The store state has already been initialized. initializeStoreState() can ' +
-                                  'only be called once BEFORE any store state has been set.');
+          'only be called once BEFORE any store state has been set.');
       }
 
     });


### PR DESCRIPTION
Using `getStateProperty` after setting a `stateSliceSelector` begins searching at the base state, not taking into account the `stateSliceSelector`.

**Steps to reproduce**
1. Set `stateSliceSelector` in the constructor of Service.
2. Call `getStateProperty` in the same Service.
3. `getStateProperty` searches properties in the base state.

**Expected behaviour**
I would expect the `getStateProperty` to search the state in the result of the `stateSliceSelector` function.

**Potential solutions**
- When using `getStateProperty`, check for a `stateSliceSelector` function, if nothing, then search at base state, if set, then begin the search at the function result.
- Have a `getStateSliceProperty` that checks for a `stateSliceSelector` and begins at the result of that function.

**Chosen solution**
- Have a `getStateSliceProperty` that checks for a `stateSliceSelector` and begins at the result of that function.