### PR TITLE
Added IsStoreInitialized static function to the Observable Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,7 +564,6 @@ Observable Store provides a simple API that can be used to get/set state, subscr
 | `static addExtension(extension: ObservableStoreExtension)`                              | Used to add an extension into ObservableStore. The extension must implement the `ObservableStoreExtension` interface. 
 | `static clearState(): void`| Clear/null the store state across all services that use it.
 | `static initializeState(state: any)`                              | Used to initialize the store's state. An error will be thrown if this is called and store state already exists so this should be set when the application first loads. No notifications are sent out to store subscribers when the store state is initialized.
-| `static isStoreInitialized()`                              | Used to determine if the the store's state is currently initialized. This is useful if there are multiple scenarios where the store might have already been initialized such as during unit testing etc or after the store has been cleared.
 | `static resetState(state, dispatchState: boolean = true)`                              | Used to reset the state of the store to a desired value for all services that derive from ObservableStore<T>. A state change notification and global state change notification is sent out to subscribers if the dispatchState parameter is true (the default value).
 <br>
 
@@ -577,6 +576,7 @@ Observable Store provides a simple API that can be used to get/set state, subscr
 | `stateHistory: StateHistory`                  | Retrieve state history. Assumes `trackStateHistory` setting was set on the store.
 | `static allStoreServices: any[]`| Provides access to all services that interact with ObservableStore. Useful for extensions that need to be able to access a specific service.
 | `static globalSettings: ObservableStoreGlobalSettings`| get/set global settings throughout the application for ObservableStore. See the [Observable Store Settings](#settings) below for additional information. Note that global settings can only be set once as the application first loads.
+| `static isStoreInitialized: boolean`                              | Used to determine if the the store's state is currently initialized. This is useful if there are multiple scenarios where the store might have already been initialized such as during unit testing etc or after the store has been cleared.
 <br>
 
 Note that TypeScript types are used to describe parameters and return types above. TypeScript is not required to use Observable Store though.

--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@ Observable Store provides a simple API that can be used to get/set state, subscr
 | `static addExtension(extension: ObservableStoreExtension)`                              | Used to add an extension into ObservableStore. The extension must implement the `ObservableStoreExtension` interface. 
 | `static clearState(): void`| Clear/null the store state across all services that use it.
 | `static initializeState(state: any)`                              | Used to initialize the store's state. An error will be thrown if this is called and store state already exists so this should be set when the application first loads. No notifications are sent out to store subscribers when the store state is initialized.
+| `static isStoreInitialized()`                              | Used to determine if the the store's state is currently initialized. This is useful if there are multiple scenarios where the store might have already been initialized such as during unit testing etc or after the store has been cleared.
 | `static resetState(state, dispatchState: boolean = true)`                              | Used to reset the state of the store to a desired value for all services that derive from ObservableStore<T>. A state change notification and global state change notification is sent out to subscribers if the dispatchState parameter is true (the default value).
 <br>
 

--- a/modules/observable-store/observable-store-base.ts
+++ b/modules/observable-store/observable-store-base.ts
@@ -22,7 +22,7 @@ class ObservableStoreBase {
     services: any[] = []; // Track all services reading/writing to store. Useful for extensions like DevToolsExtension.
 
     initializeState(state: any) {
-        if (this._storeState) {
+        if (this.isStoreInitialized()) {
             throw Error('The store state has already been initialized. initializeStoreState() can ' +
                         'only be called once BEFORE any store state has been set.');
         }
@@ -31,7 +31,7 @@ class ObservableStoreBase {
 
     getStoreState(propertyName: string = null, deepCloneReturnedState: boolean = true) {
         let state = null;
-        if (this._storeState) {
+        if (this.isStoreInitialized()) {
             // See if a specific property of the store should be returned via getStateProperty<T>()
             if (propertyName) {
                 if (this._storeState.hasOwnProperty(propertyName)) {
@@ -58,6 +58,10 @@ class ObservableStoreBase {
         else {
             this._storeState = { ...currentStoreState, ...state };
         }
+    }
+
+    isStoreInitialized(){
+        return this._storeState !== null;
     }
 
     clearStoreState() {

--- a/modules/observable-store/observable-store-base.ts
+++ b/modules/observable-store/observable-store-base.ts
@@ -21,8 +21,12 @@ class ObservableStoreBase {
     globalSettings: ObservableStoreGlobalSettings = null;
     services: any[] = []; // Track all services reading/writing to store. Useful for extensions like DevToolsExtension.
 
+    get isStoreInitialized(){
+        return this._storeState !== null;
+    }
+
     initializeState(state: any) {
-        if (this.isStoreInitialized()) {
+        if (this.isStoreInitialized) {
             throw Error('The store state has already been initialized. initializeStoreState() can ' +
                         'only be called once BEFORE any store state has been set.');
         }
@@ -31,7 +35,7 @@ class ObservableStoreBase {
 
     getStoreState(propertyName: string = null, deepCloneReturnedState: boolean = true) {
         let state = null;
-        if (this.isStoreInitialized()) {
+        if (this.isStoreInitialized) {
             // See if a specific property of the store should be returned via getStateProperty<T>()
             if (propertyName) {
                 if (this._storeState.hasOwnProperty(propertyName)) {
@@ -58,10 +62,6 @@ class ObservableStoreBase {
         else {
             this._storeState = { ...currentStoreState, ...state };
         }
-    }
-
-    isStoreInitialized(){
-        return this._storeState !== null;
     }
 
     clearStoreState() {

--- a/modules/observable-store/observable-store-base.ts
+++ b/modules/observable-store/observable-store-base.ts
@@ -21,7 +21,7 @@ class ObservableStoreBase {
     globalSettings: ObservableStoreGlobalSettings = null;
     services: any[] = []; // Track all services reading/writing to store. Useful for extensions like DevToolsExtension.
 
-    get isStoreInitialized(){
+    get isStoreInitialized(): boolean {
         return this._storeState !== null;
     }
 

--- a/modules/observable-store/observable-store.ts
+++ b/modules/observable-store/observable-store.ts
@@ -138,8 +138,8 @@ export class ObservableStore<T> {
     /**
      * Determines if the ObservableStore has already been initialized through the use of ObservableStore.initializeState()
      */
-    static isStoreInitialized(){
-        return ObservableStoreBase.isStoreInitialized();
+    static get isStoreInitialized(){
+        return ObservableStoreBase.isStoreInitialized;
     }
 
     private static dispatchToAllServices(state: any) {

--- a/modules/observable-store/observable-store.ts
+++ b/modules/observable-store/observable-store.ts
@@ -138,7 +138,7 @@ export class ObservableStore<T> {
     /**
      * Determines if the ObservableStore has already been initialized through the use of ObservableStore.initializeState()
      */
-    static get isStoreInitialized(){
+    static get isStoreInitialized(): boolean {
         return ObservableStoreBase.isStoreInitialized;
     }
 

--- a/modules/observable-store/observable-store.ts
+++ b/modules/observable-store/observable-store.ts
@@ -135,6 +135,13 @@ export class ObservableStore<T> {
         }
     }
 
+    /**
+     * Determines if the ObservableStore has already been initialized through the use of ObservableStore.initializeState()
+     */
+    static isStoreInitialized(){
+        return ObservableStoreBase.isStoreInitialized();
+    }
+
     private static dispatchToAllServices(state: any) {
         const services = ObservableStore.allStoreServices;
         if (services) {

--- a/modules/observable-store/tests/observable-store.spec.ts
+++ b/modules/observable-store/tests/observable-store.spec.ts
@@ -405,7 +405,7 @@ describe('Observable Store', () => {
 
   describe('isInitialized', () => {
     it('should return false when ObservableStore state has not yet been initialized', () => {
-      expect(ObservableStore.isStoreInitialized()).toEqual(false);
+      expect(ObservableStore.isStoreInitialized).toEqual(false);
     });
 
     it('should return true when ObservableStore state has been initialized', () => {
@@ -413,9 +413,9 @@ describe('Observable Store', () => {
         number: 420,
         awesome: false,
       }
-      expect(ObservableStore.isStoreInitialized()).toEqual(false);
+      expect(ObservableStore.isStoreInitialized).toEqual(false);
       ObservableStore.initializeState(state);
-      expect(ObservableStore.isStoreInitialized()).toEqual(true);
+      expect(ObservableStore.isStoreInitialized).toEqual(true);
     });
 
     it('should return false after the ObservableStore state has been initialized and then reset', () => {
@@ -425,7 +425,7 @@ describe('Observable Store', () => {
       }
       ObservableStore.initializeState(state);
       ObservableStore.clearState();
-      expect(ObservableStore.isStoreInitialized()).toEqual(false);
+      expect(ObservableStore.isStoreInitialized).toEqual(false);
     });
   });
 

--- a/modules/observable-store/tests/observable-store.spec.ts
+++ b/modules/observable-store/tests/observable-store.spec.ts
@@ -403,4 +403,30 @@ describe('Observable Store', () => {
     });
   });
 
+  describe('isInitialized', () => {
+    it('should return false when ObservableStore state has not yet been initialized', () => {
+      expect(ObservableStore.isStoreInitialized()).toEqual(false);
+    });
+
+    it('should return true when ObservableStore state has been initialized', () => {
+      const state = {
+        number: 420,
+        awesome: false,
+      }
+      expect(ObservableStore.isStoreInitialized()).toEqual(false);
+      ObservableStore.initializeState(state);
+      expect(ObservableStore.isStoreInitialized()).toEqual(true);
+    });
+
+    it('should return false after the ObservableStore state has been initialized and then reset', () => {
+      const state = {
+        number: 69,
+        awesome: true,
+      }
+      ObservableStore.initializeState(state);
+      ObservableStore.clearState();
+      expect(ObservableStore.isStoreInitialized()).toEqual(false);
+    });
+  });
+
 });


### PR DESCRIPTION
There are situations where it might be useful to check if the store state has already been initialised. Currently I ran into this problem when creating unit tests for individual services where I would like (maybe not smart?) to let those services initialise the state when it hasn't happened yet. 